### PR TITLE
Reformat Python to match Black standard

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -30,8 +30,7 @@ jobs:
           VALIDATE_YAML: true
           # TODO: Enable this when codebase is clang-format compliant.
           # VALIDATE_CPP: true
-          # TODO: Enable this when codebase is autopep8 compliant.
-          # VALIDATE_PYTHON: true
+          VALIDATE_PYTHON_BLACK: true
           # TODO: Enable this when codebase is bash-exec compliant.
           # VALIDATE_BASH: true 
           # VALIDATE_BASH_EXEC: true 

--- a/test/LIO_test/00_agua/check_test.py
+++ b/test/LIO_test/00_agua/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/LIO_test/01_OxyMol/check_test.py
+++ b/test/LIO_test/01_OxyMol/check_test.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
+import energy
+import forces
+import mulliken
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import mulliken
-import forces
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 mulliken.Check()
 forces.Check()
-

--- a/test/LIO_test/02_Fe3H2O6/check_test.py
+++ b/test/LIO_test/02_Fe3H2O6/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import restart
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import restart
-import energy
+sys.path.insert(0, "../../tests_engine")
 
 restart.Check()
 energy.Check()
-

--- a/test/LIO_test/03_fosfatoQMMM/check_test.py
+++ b/test/LIO_test/03_fosfatoQMMM/check_test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import mulliken
+import forces
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import forces
-import mulliken
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 forces.Check()

--- a/test/LIO_test/04_2_ECP/check_test.py
+++ b/test/LIO_test/04_2_ECP/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import dipole
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 dipole.Check()
-

--- a/test/LIO_test/04_ECP/check_test.py
+++ b/test/LIO_test/04_ECP/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import dipole
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 dipole.Check()
-

--- a/test/LIO_test/05_TDDFTField/check_test.py
+++ b/test/LIO_test/05_TDDFTField/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import restart
+import dipole
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import dipole
-import restart
+sys.path.insert(0, "../../tests_engine")
 
 dipole.Check("td")
 restart.Check()
-

--- a/test/LIO_test/06_QMinPcharges/check_test.py
+++ b/test/LIO_test/06_QMinPcharges/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import forces
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import forces
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 forces.Check()
-

--- a/test/LIO_test/07_TDDFTHCL/check_test.py
+++ b/test/LIO_test/07_TDDFTHCL/check_test.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
+import dipole
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 dipole.Check("td")
-

--- a/test/LIO_test/08_CDFT/check_test.py
+++ b/test/LIO_test/08_CDFT/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import becke
+import mulliken
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import mulliken
-import becke
+sys.path.insert(0, "../../tests_engine")
 
 mulliken.Check()
 becke.Check()
-

--- a/test/LIO_test/09_TBDFT/check_test.py
+++ b/test/LIO_test/09_TBDFT/check_test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import dipole
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 dipole.Check("td")

--- a/test/LIO_test/10_TB-DLVN/check_test.py
+++ b/test/LIO_test/10_TB-DLVN/check_test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import dipole
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 dipole.Check("td")

--- a/test/LIO_test/11_LinearSearchRho/check_test.py
+++ b/test/LIO_test/11_LinearSearchRho/check_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import energy
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()

--- a/test/LIO_test/12_Zn_timers/check_test.py
+++ b/test/LIO_test/12_Zn_timers/check_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
+import energy
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-
+sys.path.insert(0, "../../tests_engine")

--- a/test/LIO_test/13_Heme/check_test.py
+++ b/test/LIO_test/13_Heme/check_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import energy
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()

--- a/test/LIO_test/14_Moviedens/check_test.py
+++ b/test/LIO_test/14_Moviedens/check_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
-
+sys.path.insert(0, "../../tests_engine")

--- a/test/LIO_test/15_TrpDFTD/check_test.py
+++ b/test/LIO_test/15_TrpDFTD/check_test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+import energy
+import forces
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import forces
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 forces.Check()

--- a/test/LIO_test/16_AoD_test/check_test.py
+++ b/test/LIO_test/16_AoD_test/check_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import energy
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()

--- a/test/compile.py
+++ b/test/compile.py
@@ -4,101 +4,112 @@ import os
 import subprocess
 import itertools
 
+
 def set_options(flag):
-   opt = ["%s=%s" % (k,v) for (k,v) in flag_set.items()]
-   opt_str = "%s" % (" ".join(opt),)
-   options = opt_str.rstrip()
-   return options
+    opt = ["%s=%s" % (k, v) for (k, v) in flag_set.items()]
+    opt_str = "%s" % (" ".join(opt),)
+    options = opt_str.rstrip()
+    return options
 
 
 def compile_lio(options):
-   liodir = os.path.abspath("../")
-   devnull = open(os.devnull, "w")
-   cmd = ["tests_engine/build.sh", liodir, options]
-   process = subprocess.Popen(cmd, stdout=devnull, stderr=devnull)
-   process.wait()
-   return process.returncode
+    liodir = os.path.abspath("../")
+    devnull = open(os.devnull, "w")
+    cmd = ["tests_engine/build.sh", liodir, options]
+    process = subprocess.Popen(cmd, stdout=devnull, stderr=devnull)
+    process.wait()
+    return process.returncode
 
 
 def run_lio():
-   cmd = ["./new_tests.py"]
-   process = subprocess.Popen(cmd, cwd=os.path.abspath("."))
-   process.wait()
-   return process.returncode
+    cmd = ["./new_tests.py"]
+    process = subprocess.Popen(cmd, cwd=os.path.abspath("."))
+    process.wait()
+    return process.returncode
+
 
 # Verifies if CUDA is installed.
+
+
 def cuda_is_installed():
-   devnull = open(os.devnull, 'wb')
-   process = subprocess.Popen(["nvcc --version"], shell=True, stdout=devnull, stderr=devnull)
-   try:
+    devnull = open(os.devnull, "wb")
+    process = subprocess.Popen(
+        ["nvcc --version"], shell=True, stdout=devnull, stderr=devnull
+    )
+    try:
         stdout, stderr = process.communicate()
-   except:
+    except BaseException:
         process.kill()
         process.wait()
         raise
-   retcode = process.poll()
+    retcode = process.poll()
 
-   is_installed = False
-   if (retcode == 0):
-      is_installed = True
+    is_installed = False
+    if retcode == 0:
+        is_installed = True
 
-   return is_installed
+    return is_installed
+
 
 # Checks if Intel compilers are present.
+
+
 def intel_is_installed():
-   devnull = open(os.devnull, 'wb')
-   process = subprocess.Popen(["icc --version"], shell=True, stdout=devnull, stderr=devnull)
-   try:
+    devnull = open(os.devnull, "wb")
+    process = subprocess.Popen(
+        ["icc --version"], shell=True, stdout=devnull, stderr=devnull
+    )
+    try:
         stdout, stderr = process.communicate()
-   except:
+    except BaseException:
         process.kill()
         process.wait()
         raise
-   retcode = process.poll()
+    retcode = process.poll()
 
-   is_installed = False
-   if (retcode == 0):
-      is_installed = True
+    is_installed = False
+    if retcode == 0:
+        is_installed = True
 
-   return is_installed
+    return is_installed
 
 
 if __name__ == "__main__":
-   comp = ["precision"]
+    comp = ["precision"]
 
-   if (cuda_is_installed()):
-      comp.append("cuda")
-   if (intel_is_installed()):
-      comp.append("intel")
-   seq = list(itertools.product(["0","1"],repeat=len(comp)))
-   all_sets = []
+    if cuda_is_installed():
+        comp.append("cuda")
+    if intel_is_installed():
+        comp.append("intel")
+    seq = list(itertools.product(["0", "1"], repeat=len(comp)))
+    all_sets = []
 
-   for cases in seq:
-      compile_opts = dict([(comp[i],cases[i]) for i in range(0,len(comp))])
-      if (cuda_is_installed()):
-         if compile_opts["cuda"] == "1":
-            compile_opts["cuda"] =  "2"
+    for cases in seq:
+        compile_opts = dict([(comp[i], cases[i]) for i in range(0, len(comp))])
+        if cuda_is_installed():
+            if compile_opts["cuda"] == "1":
+                compile_opts["cuda"] = "2"
 
-      if (intel_is_installed()):
-         if compile_opts["intel"] == "1":
-            compile_opts["intel"] =  "2"
+        if intel_is_installed():
+            if compile_opts["intel"] == "1":
+                compile_opts["intel"] = "2"
 
-      all_sets.append(compile_opts)
+        all_sets.append(compile_opts)
 
-   for flag_set in all_sets:
-      opts = set_options(flag_set)
-      if (not cuda_is_installed()):
-         opts = opts + " cuda=0 "
-      print("Compiling LIO with Options: %s" % opts.rstrip())
-      error = compile_lio(opts)
-      if not error:
-         print("\tSuccessfully compiled.")
-      else:
-         print("\tError!")
- 
-      error = run_lio()
-      if not error:
-         print("run_lio successfully finished.")
-      else:
-         print("run_lio Error!")
-         exit(-1)
+    for flag_set in all_sets:
+        opts = set_options(flag_set)
+        if not cuda_is_installed():
+            opts = opts + " cuda=0 "
+        print("Compiling LIO with Options: %s" % opts.rstrip())
+        error = compile_lio(opts)
+        if not error:
+            print("\tSuccessfully compiled.")
+        else:
+            print("\tError!")
+
+        error = run_lio()
+        if not error:
+            print("run_lio successfully finished.")
+        else:
+            print("run_lio Error!")
+            exit(-1)

--- a/test/extern_functionals/cam_b3lyp/check_test.py
+++ b/test/extern_functionals/cam_b3lyp/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/extern_functionals/pbe0/check_test.py
+++ b/test/extern_functionals/pbe0/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/new_tests.py
+++ b/test/new_tests.py
@@ -7,7 +7,7 @@ import subprocess
 
 
 def lio_env():
-    """"
+    """
     Sets lio enviroment variables, adding g2g and
     lioamber to LD_LIBRARY_PATH.
     """

--- a/test/new_tests.py
+++ b/test/new_tests.py
@@ -5,64 +5,68 @@ import os
 import argparse
 import subprocess
 
-def lio_env():
-   """"
-   Sets lio enviroment variables, adding g2g and
-   lioamber to LD_LIBRARY_PATH.
-   """
 
-   lioenv = os.environ.copy()
-   lioenv["LIOBIN"] = os.path.abspath("../liosolo/liosolo")
-   dirs = ["../g2g", "../lioamber"]
-   try:
-      prev = lioenv["LD_LIBRARY_PATH"]
-   except:
-      prev = ""
-   lioenv["LD_LIBRARY_PATH"] = ":".join([prev] + [os.path.abspath(p) for p in dirs])
-   lioenv["LIOHOME"] = os.path.abspath("../")
-   return lioenv
+def lio_env():
+    """"
+    Sets lio enviroment variables, adding g2g and
+    lioamber to LD_LIBRARY_PATH.
+    """
+
+    lioenv = os.environ.copy()
+    lioenv["LIOBIN"] = os.path.abspath("../liosolo/liosolo")
+    dirs = ["../g2g", "../lioamber"]
+    try:
+        prev = lioenv["LD_LIBRARY_PATH"]
+    except BaseException:
+        prev = ""
+    lioenv["LD_LIBRARY_PATH"] = ":".join([prev] + [os.path.abspath(p) for p in dirs])
+    lioenv["LIOHOME"] = os.path.abspath("../")
+    return lioenv
 
 
 def run_lio(dirs_with_tests):
-   "Runs all Tests"
-   lioenv = lio_env()
+    "Runs all Tests"
+    lioenv = lio_env()
 
-   for dir in dirs_with_tests:
-      is_file = os.path.isfile(os.path.abspath(dir) + "/run.sh")
-      print("Running LIO in",dir)
+    for dir in dirs_with_tests:
+        is_file = os.path.isfile(os.path.abspath(dir) + "/run.sh")
+        print("Running LIO in", dir)
 
-      if is_file:
-        execpath = ["./run.sh"]
-        process = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
-        process.wait()
-        if process.returncode != 0:
-           print("Error in this folder.")
-           continue
+        if is_file:
+            execpath = ["./run.sh"]
+            process = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
+            process.wait()
+            if process.returncode != 0:
+                print("Error in this folder.")
+                continue
+            else:
+                is_file = os.path.isfile(os.path.abspath(dir) + "/check_test.py")
+                if is_file:
+                    execpath = ["./check_test.py"]
+                    check = subprocess.Popen(
+                        execpath, env=lioenv, cwd=os.path.abspath(dir)
+                    )
+                    check.wait()
+                else:
+                    print("check_test.py not found.")
         else:
-           is_file = os.path.isfile(os.path.abspath(dir) + "/check_test.py")
-           if is_file:
-              execpath = ["./check_test.py"]
-              check = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
-              check.wait()
-           else:
-              print("check_test.py not found.")
-      else:
-        print("Nothing to do.")
+            print("Nothing to do.")
 
 
 if __name__ == "__main__":
-   parser = argparse.ArgumentParser()
-   parser.add_argument("--filter_rx", help="RegExp used to filter which tests are run.", default=".*")
-   args = parser.parse_args()
-   filterrx = args.filter_rx
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--filter_rx", help="RegExp used to filter which tests are run.", default=".*"
+    )
+    args = parser.parse_args()
+    filterrx = args.filter_rx
 
-   # This obtain tests folder
-   subdirs = list(os.walk('LIO_test/'))[0][1]
-   dirs_with_tests = sorted([d for d in subdirs if re.search(filterrx,d)])
-   total = len(dirs_with_tests)
-   for i in range(0,total):
-      dirs_with_tests[i] = "LIO_test/" + dirs_with_tests[i]
+    # This obtain tests folder
+    subdirs = list(os.walk("LIO_test/"))[0][1]
+    dirs_with_tests = sorted([d for d in subdirs if re.search(filterrx, d)])
+    total = len(dirs_with_tests)
+    for i in range(0, total):
+        dirs_with_tests[i] = "LIO_test/" + dirs_with_tests[i]
 
-   # Run lio
-   filed = run_lio(dirs_with_tests)
-
+    # Run lio
+    filed = run_lio(dirs_with_tests)

--- a/test/run_travis_test.py
+++ b/test/run_travis_test.py
@@ -5,60 +5,62 @@ import os
 import argparse
 import subprocess
 
-def lio_env():
-   """"
-   Sets lio enviroment variables, adding g2g and
-   lioamber to LD_LIBRARY_PATH.
-   """
 
-   lioenv = os.environ.copy()
-   lioenv["LIOBIN"] = os.path.abspath("../liosolo/liosolo")
-   dirs = ["../g2g", "../lioamber"]
-   try:
-      prev = lioenv["LD_LIBRARY_PATH"]
-   except:
-      prev = ""
-   lioenv["LD_LIBRARY_PATH"] = ":".join([prev] + [os.path.abspath(p) for p in dirs])
-   lioenv["LIOHOME"] = os.path.abspath("../")
-   return lioenv
+def lio_env():
+    """"
+    Sets lio enviroment variables, adding g2g and
+    lioamber to LD_LIBRARY_PATH.
+    """
+
+    lioenv = os.environ.copy()
+    lioenv["LIOBIN"] = os.path.abspath("../liosolo/liosolo")
+    dirs = ["../g2g", "../lioamber"]
+    try:
+        prev = lioenv["LD_LIBRARY_PATH"]
+    except BaseException:
+        prev = ""
+    lioenv["LD_LIBRARY_PATH"] = ":".join([prev] + [os.path.abspath(p) for p in dirs])
+    lioenv["LIOHOME"] = os.path.abspath("../")
+    return lioenv
 
 
 def run_lio(dirs_with_tests):
-   "Runs all Tests"
-   lioenv = lio_env()
+    "Runs all Tests"
+    lioenv = lio_env()
 
-   for dir in dirs_with_tests:
-      is_file = os.path.isfile(os.path.abspath(dir) + "/run.sh")
-      print("Running LIO in",dir)
+    for dir in dirs_with_tests:
+        is_file = os.path.isfile(os.path.abspath(dir) + "/run.sh")
+        print("Running LIO in", dir)
 
-      if is_file:
-        execpath = ["./run.sh"]
-        process = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
-        process.wait()
-        if process.returncode != 0:
-           print("Error in this folder.")
-           continue
+        if is_file:
+            execpath = ["./run.sh"]
+            process = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
+            process.wait()
+            if process.returncode != 0:
+                print("Error in this folder.")
+                continue
+            else:
+                execpath = ["./check_test.py"]
+                check = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
+                check.wait()
         else:
-           execpath = ["./check_test.py"]
-           check = subprocess.Popen(execpath, env=lioenv, cwd=os.path.abspath(dir))
-           check.wait()
-      else:
-        print("Nothing to do.")
+            print("Nothing to do.")
 
 
 if __name__ == "__main__":
-   parser = argparse.ArgumentParser()
-   parser.add_argument("--filter_rx", help="RegExp used to filter which tests are run.", default=".*")
-   args = parser.parse_args()
-   filterrx = args.filter_rx
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--filter_rx", help="RegExp used to filter which tests are run.", default=".*"
+    )
+    args = parser.parse_args()
+    filterrx = args.filter_rx
 
-   # This obtain tests folder
-   subdirs = list(os.walk('LIO_test/'))[0][1]
-   dirs_with_tests = sorted([d for d in subdirs if re.search(filterrx,d)])
-   test_folders = [0,1,3,4,7]
-   for i in test_folders:
-      dirs_with_tests[i] = "LIO_test/" + dirs_with_tests[i]
+    # This obtain tests folder
+    subdirs = list(os.walk("LIO_test/"))[0][1]
+    dirs_with_tests = sorted([d for d in subdirs if re.search(filterrx, d)])
+    test_folders = [0, 1, 3, 4, 7]
+    for i in test_folders:
+        dirs_with_tests[i] = "LIO_test/" + dirs_with_tests[i]
 
-   # Run lio
-   filed = run_lio(dirs_with_tests)
-
+    # Run lio
+    filed = run_lio(dirs_with_tests)

--- a/test/run_travis_test.py
+++ b/test/run_travis_test.py
@@ -7,7 +7,7 @@ import subprocess
 
 
 def lio_env():
-    """"
+    """
     Sets lio enviroment variables, adding g2g and
     lioamber to LD_LIBRARY_PATH.
     """

--- a/test/testLR/ESAs/ESAfosc/check_test.py
+++ b/test/testLR/ESAs/ESAfosc/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/testLR/agua/check_test.py
+++ b/test/testLR/agua/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/testLR/indol/check_test.py
+++ b/test/testLR/indol/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/testLR/truncated_LR/delete_mos/check_test.py
+++ b/test/testLR/truncated_LR/delete_mos/check_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
+import energy
+import dipole
+import forces
+import mulliken
+import fukui
 import sys
 
-sys.path.insert(0,"../../tests_engine")
-import energy 
-import fukui
-import mulliken
-import forces
-import dipole
+sys.path.insert(0, "../../tests_engine")
 
 energy.Check()
 fukui.Check()
 mulliken.Check()
 forces.Check()
 dipole.Check()
-

--- a/test/tests_engine/becke.py
+++ b/test/tests_engine/becke.py
@@ -6,11 +6,11 @@ import os
 def obtain_becke(file_in):
     lista = []
     for line in file_in.readlines():
-        m = re.match("\\s+\\d+\\s+\\d+\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+\d+\s+\d+\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 
-        m = re.match("\\s+Total Charge =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Total Charge =\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 

--- a/test/tests_engine/becke.py
+++ b/test/tests_engine/becke.py
@@ -2,69 +2,71 @@
 import re
 import os
 
+
 def obtain_becke(file_in):
-   lista = []
-   for line in file_in.readlines():
-      m = re.match("\s+\d+\s+\d+\s+([0-9.-]+)",line)
-      if m:
-         lista.append(float(m.group(1)))
+    lista = []
+    for line in file_in.readlines():
+        m = re.match("\\s+\\d+\\s+\\d+\\s+([0-9.-]+)", line)
+        if m:
+            lista.append(float(m.group(1)))
 
-      m = re.match("\s+Total Charge =\s+([0-9.-]+)",line)
-      if m:
-         lista.append(float(m.group(1)))
+        m = re.match("\\s+Total Charge =\\s+([0-9.-]+)", line)
+        if m:
+            lista.append(float(m.group(1)))
 
-   return lista
+    return lista
 
-def error(mull,mull_ok):
-   dim1 = len(mull)
-   dim2 = len(mull_ok)
-   scr = 0
-   if dim1 != dim2:
-      print("There are diffenrent becke charges in outputs.")
-      return -1
 
-   for num in range(dim1):
-      value = abs(mull[num] - mull_ok[num])
-      if value > 1e-2:
-         src = -1
-         print("Error in becke charges:")
-         print("Valor en becke",mull[num])
-         print("Valor en becke.ok",mull_ok[num])
+def error(mull, mull_ok):
+    dim1 = len(mull)
+    dim2 = len(mull_ok)
+    scr = 0
+    if dim1 != dim2:
+        print("There are diffenrent becke charges in outputs.")
+        return -1
 
-   return scr
+    for num in range(dim1):
+        value = abs(mull[num] - mull_ok[num])
+        if value > 1e-2:
+            src = -1
+            print("Error in becke charges:")
+            print("Valor en becke", mull[num])
+            print("Valor en becke.ok", mull_ok[num])
+
+    return scr
 
 
 def Check():
-   # Output
-   mull = []
-   is_file = os.path.isfile("becke")
-   if is_file == False:
-      print("The becke file is missing.")
-      return -1
+    # Output
+    mull = []
+    is_file = os.path.isfile("becke")
+    if not is_file:
+        print("The becke file is missing.")
+        return -1
 
-   f = open("becke","r")
-   mull = obtain_becke(f)
-   f.close()
-   if not mull:
-      print("Error in reading becke.")
-      return -1
+    f = open("becke", "r")
+    mull = obtain_becke(f)
+    f.close()
+    if not mull:
+        print("Error in reading becke.")
+        return -1
 
-   # Ideal Output
-   is_file = os.path.isfile("becke.ok")
-   if is_file == False:
-      print("The becke.ok file is missing.")
-      return -1
+    # Ideal Output
+    is_file = os.path.isfile("becke.ok")
+    if not is_file:
+        print("The becke.ok file is missing.")
+        return -1
 
-   f = open("becke.ok","r")
-   mullok = []
-   mullok = obtain_becke(f)
-   f.close()
-   if not mullok:
-      print("Error in reading becke.ok.")
-      return -1
+    f = open("becke.ok", "r")
+    mullok = []
+    mullok = obtain_becke(f)
+    f.close()
+    if not mullok:
+        print("Error in reading becke.ok.")
+        return -1
 
-   ok_output = error(mull,mullok)
-   if ok_output != 0:
-      print("Test Becke:      ERROR")
-   else:
-      print("Test Becke:      OK")
+    ok_output = error(mull, mullok)
+    if ok_output != 0:
+        print("Test Becke:      ERROR")
+    else:
+        print("Test Becke:      OK")

--- a/test/tests_engine/dipole.py
+++ b/test/tests_engine/dipole.py
@@ -2,78 +2,81 @@
 import re
 import os
 
+
 def obtain_dipole(file_in):
-   dip = []
-   condition = re.match("\w+td",file_in.name)
+    dip = []
+    condition = re.match("\\w+td", file_in.name)
 
-   if condition:
-      patron = "\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)"
-   else:
-      patron = "\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)"
+    if condition:
+        patron = "\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)"
+    else:
+        patron = "\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)"
 
-   for line in file_in.readlines():
-      m = re.match(patron,line)
-      if m:
-         dip.append(float(m.group(4)))
+    for line in file_in.readlines():
+        m = re.match(patron, line)
+        if m:
+            dip.append(float(m.group(4)))
 
-   return dip
+    return dip
 
-def error(dip,dip_ok):
-   dim1 = len(dip)
-   dim2 = len(dip_ok)
-   scr = 0
-   if dim1 != dim2:
-      print("There are differents dipole moment in both outputs")
-      return -1
 
-   for num in range(dim1):
-      value = abs(dip[num] - dip_ok[num])
-      if value > 1e-3:
-         src = -1
-         print("Error in dipole:")
-         print("Value of dipole moment",dip[num])
-         print("Value of ideal dipole moment",dip_ok[num])
+def error(dip, dip_ok):
+    dim1 = len(dip)
+    dim2 = len(dip_ok)
+    scr = 0
+    if dim1 != dim2:
+        print("There are differents dipole moment in both outputs")
+        return -1
 
-   return scr
+    for num in range(dim1):
+        value = abs(dip[num] - dip_ok[num])
+        if value > 1e-3:
+            src = -1
+            print("Error in dipole:")
+            print("Value of dipole moment", dip[num])
+            print("Value of ideal dipole moment", dip_ok[num])
+
+    return scr
+
 
 def Check(*opt):
-   option = "".join(opt)
+    option = "".join(opt)
 
-   # Ouput
-   if option == "td":
-      file_in = "dipole_moment_td"
-   else:
-      file_in = "dipole_moment"
+    # Ouput
+    if option == "td":
+        file_in = "dipole_moment_td"
+    else:
+        file_in = "dipole_moment"
 
-   dip = []
-   is_file = os.path.isfile(file_in)
-   if is_file == False:
-      print("The %s file is missing." % file_in)
-      return -1
+    dip = []
+    is_file = os.path.isfile(file_in)
+    if not is_file:
+        print("The %s file is missing." % file_in)
+        return -1
 
-   f = open(file_in,"r")
-   dip = obtain_dipole(f)
-   f.close()
-   if not dip:
-      print("Error reading in %s." % file_in)
-      return -1
+    f = open(file_in, "r")
+    dip = obtain_dipole(f)
+    f.close()
+    if not dip:
+        print("Error reading in %s." % file_in)
+        return -1
 
-   # Ideal Ouput
-   file_ok = file_in + ".ok"
-   dipok = []
-   is_file = os.path.isfile(file_ok)
-   if is_file == False:
-      print("The %s file is missing." % file_ok)
-      return -1
+    # Ideal Ouput
+    file_ok = file_in + ".ok"
+    dipok = []
+    is_file = os.path.isfile(file_ok)
+    if not is_file:
+        print("The %s file is missing." % file_ok)
+        return -1
 
-   f = open(file_ok,"r")
-   dipok = obtain_dipole(f)
-   f.close()
-   if not dipok:
-      print("Error reading in %s." % file_ok)
+    f = open(file_ok, "r")
+    dipok = obtain_dipole(f)
+    f.close()
+    if not dipok:
+        print("Error reading in %s." % file_ok)
 
-   ok_output = error(dip,dipok)
-   if ok_output != 0:
-      print("Test Dipole:     ERROR")
-   else:
-      print("Test Dipole:     OK")
+    ok_output = error(dip, dipok)
+    if ok_output != 0:
+        print("Test Dipole:     ERROR")
+    else:
+        print("Test Dipole:     OK")

--- a/test/tests_engine/dipole.py
+++ b/test/tests_engine/dipole.py
@@ -8,9 +8,11 @@ def obtain_dipole(file_in):
     condition = re.match("\\w+td", file_in.name)
 
     if condition:
-        patron = "\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)"
+        patron = r"\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)"
     else:
-        patron = "\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)"
+        patron = (
+            r"\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)"
+        )
 
     for line in file_in.readlines():
         m = re.match(patron, line)

--- a/test/tests_engine/energy.py
+++ b/test/tests_engine/energy.py
@@ -8,47 +8,47 @@ def obtain_energies(file_in):
     energies = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     for line in file_in.readlines():
         # Total Energy
-        m = re.match("\\s+Total energy =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Total energy =\s+([0-9.-]+)", line)
         if m:
             energies[0] = float(m.group(1))
 
         # One Electron Energy
-        m = re.match("\\s+One electron =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+One electron =\s+([0-9.-]+)", line)
         if m:
             energies[1] = float(m.group(1))
 
         # Coulomb Energy
-        m = re.match("\\s+Coulomb\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Coulomb\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[2] = float(m.group(1))
 
         # Nuclear Energy
-        m = re.match("\\s+Nuclear\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Nuclear\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[3] = float(m.group(1))
 
         # Correlation - Exchange Energy
-        m = re.match("\\s+Exch. Corr.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Exch. Corr.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[4] = float(m.group(1))
 
         # Exact exchange for hybrid functionals.
-        m = re.match("\\s+Exact. Exc.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Exact. Exc.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[5] = float(m.group(1))
 
         # QM-MM nuclear repulsion.
-        m = re.match("\\s+QM-MM nuc.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+QM-MM nuc.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[6] = float(m.group(1))
 
         # QM-MM electron attraction.
-        m = re.match("\\s+QM-MM elec.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+QM-MM elec.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[7] = float(m.group(1))
 
         # DFT-D3 energy.
-        m = re.match("\\s+DFTD3 Energy =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+DFTD3 Energy =\s+([0-9.-]+)", line)
         if m:
             energies[8] = float(m.group(1))
 

--- a/test/tests_engine/energy.py
+++ b/test/tests_engine/energy.py
@@ -3,114 +3,126 @@ import re
 import os
 import subprocess
 
+
 def obtain_energies(file_in):
-   energies = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
-   for line in file_in.readlines():
-      # Total Energy
-      m = re.match("\s+Total energy =\s+([0-9.-]+)",line)
-      if m:
-         energies[0] = (float(m.group(1)))
+    energies = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    for line in file_in.readlines():
+        # Total Energy
+        m = re.match("\\s+Total energy =\\s+([0-9.-]+)", line)
+        if m:
+            energies[0] = float(m.group(1))
 
-      # One Electron Energy
-      m = re.match("\s+One electron =\s+([0-9.-]+)",line)
-      if m:
-         energies[1] = (float(m.group(1)))
+        # One Electron Energy
+        m = re.match("\\s+One electron =\\s+([0-9.-]+)", line)
+        if m:
+            energies[1] = float(m.group(1))
 
-      # Coulomb Energy
-      m = re.match("\s+Coulomb\s+ =\s+([0-9.-]+)",line)
-      if m:
-         energies[2] = (float(m.group(1)))
+        # Coulomb Energy
+        m = re.match("\\s+Coulomb\\s+ =\\s+([0-9.-]+)", line)
+        if m:
+            energies[2] = float(m.group(1))
 
-      # Nuclear Energy
-      m = re.match("\s+Nuclear\s+ =\s+([0-9.-]+)",line)
-      if m:
-         energies[3] = (float(m.group(1)))
+        # Nuclear Energy
+        m = re.match("\\s+Nuclear\\s+ =\\s+([0-9.-]+)", line)
+        if m:
+            energies[3] = float(m.group(1))
 
-      # Correlation - Exchange Energy
-      m = re.match("\s+Exch. Corr.\s+ =\s+([0-9.-]+)",line)
-      if m:
-         energies[4] = (float(m.group(1)))
+        # Correlation - Exchange Energy
+        m = re.match("\\s+Exch. Corr.\\s+ =\\s+([0-9.-]+)", line)
+        if m:
+            energies[4] = float(m.group(1))
 
-      # Exact exchange for hybrid functionals.
-      m = re.match("\s+Exact. Exc.\s+ =\s+([0-9.-]+)",line)
-      if m:
-         energies[5] = (float(m.group(1)))
+        # Exact exchange for hybrid functionals.
+        m = re.match("\\s+Exact. Exc.\\s+ =\\s+([0-9.-]+)", line)
+        if m:
+            energies[5] = float(m.group(1))
 
-      # QM-MM nuclear repulsion.
-      m = re.match("\s+QM-MM nuc.\s+ =\s+([0-9.-]+)",line)
-      if m:
-         energies[6] = (float(m.group(1)))
+        # QM-MM nuclear repulsion.
+        m = re.match("\\s+QM-MM nuc.\\s+ =\\s+([0-9.-]+)", line)
+        if m:
+            energies[6] = float(m.group(1))
 
-      # QM-MM electron attraction.
-      m = re.match("\s+QM-MM elec.\s+ =\s+([0-9.-]+)",line)
-      if m:
-         energies[7] = (float(m.group(1)))
+        # QM-MM electron attraction.
+        m = re.match("\\s+QM-MM elec.\\s+ =\\s+([0-9.-]+)", line)
+        if m:
+            energies[7] = float(m.group(1))
 
-      # DFT-D3 energy.
-      m = re.match("\s+DFTD3 Energy =\s+([0-9.-]+)",line)
-      if m:
-         energies[8] = (float(m.group(1)))
+        # DFT-D3 energy.
+        m = re.match("\\s+DFTD3 Energy =\\s+([0-9.-]+)", line)
+        if m:
+            energies[8] = float(m.group(1))
 
-   if len(energies) < 1:
-      return -1
+    if len(energies) < 1:
+        return -1
 
-   return energies
+    return energies
 
-def error(ene,ene_ok):
-   tipo = ["Total energy","One electron","Coulomb","Nuclear","Exch. Corr.","Exact Exch.","QM-MM nuclear","QM-MM electronic","DFT-D3"]
-   dim1 = len(ene)
-   dim2 = len(ene_ok)
-   scr = 0
-   if dim1 != dim2:
-      print("There are different energies in both outputs.")
-      return -1
 
-   for num in range(dim1):
-      value = abs(ene[num] - ene_ok[num])
-      thre = 1.5e-2
-      if tipo[num] == "Total energy":
-         thre = 1.5e-4
-      if value > thre:
-         scr = -1
-         print("Error in",tipo[num])
-         print("Value in output", ene[num])
-         print("Value in output.ok", ene_ok[num])
+def error(ene, ene_ok):
+    tipo = [
+        "Total energy",
+        "One electron",
+        "Coulomb",
+        "Nuclear",
+        "Exch. Corr.",
+        "Exact Exch.",
+        "QM-MM nuclear",
+        "QM-MM electronic",
+        "DFT-D3",
+    ]
+    dim1 = len(ene)
+    dim2 = len(ene_ok)
+    scr = 0
+    if dim1 != dim2:
+        print("There are different energies in both outputs.")
+        return -1
 
-   return scr
+    for num in range(dim1):
+        value = abs(ene[num] - ene_ok[num])
+        thre = 1.5e-2
+        if tipo[num] == "Total energy":
+            thre = 1.5e-4
+        if value > thre:
+            scr = -1
+            print("Error in", tipo[num])
+            print("Value in output", ene[num])
+            print("Value in output.ok", ene_ok[num])
+
+    return scr
 
 
 def Check():
-   # Output
-   is_file = os.path.isfile("output")
-   if is_file == False:
-      print("The output file is missing.")
-      return -1
+    # Output
+    is_file = os.path.isfile("output")
+    if not is_file:
+        print("The output file is missing.")
+        return -1
 
-   f = open("output","r")
-   energies = []
-   energies = obtain_energies(f)
-   f.close()
-   if not energies:
-      print("Error in reading energies in output.")
-      return -1
+    f = open("output", "r")
+    energies = []
+    energies = obtain_energies(f)
+    f.close()
+    if not energies:
+        print("Error in reading energies in output.")
+        return -1
 
-   # Ideal Output
-   is_file = os.path.isfile("output.ok")
-   if is_file == False:
-      print("The output.ok file is missing.")
-      return -1
+    # Ideal Output
+    is_file = os.path.isfile("output.ok")
+    if not is_file:
+        print("The output.ok file is missing.")
+        return -1
 
-   f = open("output.ok","r")
-   energiesok = []
-   energiesok = obtain_energies(f)
-   f.close()
-   if not energiesok:
-      print("Error in reading energies in output.ok.")
-      return -1
+    f = open("output.ok", "r")
+    energiesok = []
+    energiesok = obtain_energies(f)
+    f.close()
+    if not energiesok:
+        print("Error in reading energies in output.ok.")
+        return -1
 
-   ok_output = error(energies,energiesok)
-   
-   if ok_output != 0:
-      print("Test Energy:     ERROR")
-   else:
-      print("Test Energy:     OK")
+    ok_output = error(energies, energiesok)
+
+    if ok_output != 0:
+        print("Test Energy:     ERROR")
+    else:
+        print("Test Energy:     OK")

--- a/test/tests_engine/forces.py
+++ b/test/tests_engine/forces.py
@@ -6,7 +6,7 @@ import os
 def obtain_forces(file_in):
     lista = []
     for line in file_in.readlines():
-        m = re.match("\\s+\\d+\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+\d+\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
             lista.append(float(m.group(2)))

--- a/test/tests_engine/forces.py
+++ b/test/tests_engine/forces.py
@@ -2,65 +2,68 @@
 import re
 import os
 
+
 def obtain_forces(file_in):
-   lista = []
-   for line in file_in.readlines():
-      m = re.match("\s+\d+\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)",line)
-      if m:
-         lista.append(float(m.group(1)))
-         lista.append(float(m.group(2)))
-         lista.append(float(m.group(3)))
+    lista = []
+    for line in file_in.readlines():
+        m = re.match("\\s+\\d+\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)", line)
+        if m:
+            lista.append(float(m.group(1)))
+            lista.append(float(m.group(2)))
+            lista.append(float(m.group(3)))
 
-   return lista
+    return lista
 
-def error(fc,fc_ok):
-   dim1 = len(fc)
-   dim2 = len(fc_ok)
-   scr = 0
-   if dim1 != dim2:
-      print("Amount of forces in forces and forces.ok is different.")
-      return -1
 
-   for num in range(dim1):
-      value = abs(fc[num] - fc_ok[num])
-      if value > 1e-3:
-         scr = -1
-         print("Error detected in Forces:")
-         print("Value in forces",fc[num])
-         print("Value in forces.ok",fc_ok[num])
+def error(fc, fc_ok):
+    dim1 = len(fc)
+    dim2 = len(fc_ok)
+    scr = 0
+    if dim1 != dim2:
+        print("Amount of forces in forces and forces.ok is different.")
+        return -1
 
-   return scr
+    for num in range(dim1):
+        value = abs(fc[num] - fc_ok[num])
+        if value > 1e-3:
+            scr = -1
+            print("Error detected in Forces:")
+            print("Value in forces", fc[num])
+            print("Value in forces.ok", fc_ok[num])
+
+    return scr
+
 
 def Check():
-   # Output
-   fc = []
-   is_file = os.path.isfile("forces")
-   if is_file == False:
-      print("The forces file is missing.")
-      return -1
+    # Output
+    fc = []
+    is_file = os.path.isfile("forces")
+    if not is_file:
+        print("The forces file is missing.")
+        return -1
 
-   f = open("forces","r")
-   fc = obtain_forces(f)
-   f.close()
-   if not fc:
-      print("Error reading in forces.")
-      return -1
+    f = open("forces", "r")
+    fc = obtain_forces(f)
+    f.close()
+    if not fc:
+        print("Error reading in forces.")
+        return -1
 
-   is_file = os.path.isfile("forces.ok")
-   if is_file == False:
-      print("The forces.ok file is missing.")
-      return -1
+    is_file = os.path.isfile("forces.ok")
+    if not is_file:
+        print("The forces.ok file is missing.")
+        return -1
 
-   fcok = []
-   f = open("forces.ok","r")
-   fcok = obtain_forces(f)
-   f.close()
-   if not fcok:
-      print("Error reading in forces.ok.")
-      return -1
+    fcok = []
+    f = open("forces.ok", "r")
+    fcok = obtain_forces(f)
+    f.close()
+    if not fcok:
+        print("Error reading in forces.ok.")
+        return -1
 
-   ok_output = error(fc,fcok)
-   if ok_output != 0:
-      print("Test Forces:     ERROR")
-   else:
-      print("Test Forces:     OK")
+    ok_output = error(fc, fcok)
+    if ok_output != 0:
+        print("Test Forces:     ERROR")
+    else:
+        print("Test Forces:     OK")

--- a/test/tests_engine/fukui.py
+++ b/test/tests_engine/fukui.py
@@ -2,71 +2,75 @@
 import re
 import os
 
+
 def obtain_fukui(file_in):
-   lista = []
-   for line in file_in.readlines():
-      m = re.match("\s+\d+\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)",line)
-      if m:
-         lista.append(float(m.group(1)))
-         lista.append(float(m.group(2)))
-         lista.append(float(m.group(3)))
-         lista.append(float(m.group(4)))
+    lista = []
+    for line in file_in.readlines():
+        m = re.match(
+            "\\s+\\d+\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)", line
+        )
+        if m:
+            lista.append(float(m.group(1)))
+            lista.append(float(m.group(2)))
+            lista.append(float(m.group(3)))
+            lista.append(float(m.group(4)))
 
-   if len(lista) < 1:
-      return -1
+    if len(lista) < 1:
+        return -1
 
-   return lista
+    return lista
 
-def error(fuk,fukok):
-   dim1 = len(fuk)
-   dim2 = len(fukok)
-   scr = 0
 
-   if dim1 != dim2:
-      print("There are different number of Fukui charges in outputs.")
-      return -1
+def error(fuk, fukok):
+    dim1 = len(fuk)
+    dim2 = len(fukok)
+    scr = 0
 
-   for num in range(dim1):
-      value = abs(fuk[num] - fukok[num])
-      if value > 1e-2:
-          scr = 1
-          print("Error in fukui:")
-          print("Value of fukui",fuk[num])
-          print("Value of fukui.ok",fukok[num])
+    if dim1 != dim2:
+        print("There are different number of Fukui charges in outputs.")
+        return -1
 
-   return scr
+    for num in range(dim1):
+        value = abs(fuk[num] - fukok[num])
+        if value > 1e-2:
+            scr = 1
+            print("Error in fukui:")
+            print("Value of fukui", fuk[num])
+            print("Value of fukui.ok", fukok[num])
+
+    return scr
+
 
 def Check():
-   # Output
-   fuk = []
-   is_file = os.path.isfile("fukui")
-   if is_file == False:
-      print("The fukui file is missing.")
-      return -1
+    # Output
+    fuk = []
+    is_file = os.path.isfile("fukui")
+    if not is_file:
+        print("The fukui file is missing.")
+        return -1
 
-   f = open("fukui","r")
-   fuk = obtain_fukui(f)
-   f.close
-   if not fuk:
-      print("Error in reading fukui.")
+    f = open("fukui", "r")
+    fuk = obtain_fukui(f)
+    f.close
+    if not fuk:
+        print("Error in reading fukui.")
 
-   # Ideal Output
-   fukok = []
-   is_file = os.path.isfile("fukui")
-   if is_file == False:
-      print("The fukui.ok file is missing.")
-      return -1
+    # Ideal Output
+    fukok = []
+    is_file = os.path.isfile("fukui")
+    if not is_file:
+        print("The fukui.ok file is missing.")
+        return -1
 
-   f = open("fukui.ok","r")
-   fukok = obtain_fukui(f)
-   f.close
-   if not fukok:
-      print("Error in reading fukui.ok.")
+    f = open("fukui.ok", "r")
+    fukok = obtain_fukui(f)
+    f.close
+    if not fukok:
+        print("Error in reading fukui.ok.")
 
-   ok_output = error(fuk,fukok)
-  
-   if ok_output != 0:
-      print("Test Fukui:      ERROR")
-   else:
-      print("Test Fukui:      OK")
+    ok_output = error(fuk, fukok)
 
+    if ok_output != 0:
+        print("Test Fukui:      ERROR")
+    else:
+        print("Test Fukui:      OK")

--- a/test/tests_engine/fukui.py
+++ b/test/tests_engine/fukui.py
@@ -7,7 +7,7 @@ def obtain_fukui(file_in):
     lista = []
     for line in file_in.readlines():
         m = re.match(
-            "\\s+\\d+\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)", line
+            r"\s+\d+\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)", line
         )
         if m:
             lista.append(float(m.group(1)))

--- a/test/tests_engine/mulliken.py
+++ b/test/tests_engine/mulliken.py
@@ -6,11 +6,11 @@ import os
 def obtain_mulliken(file_in):
     lista = []
     for line in file_in.readlines():
-        m = re.match("\\s+\\d+\\s+\\d+\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+\d+\s+\d+\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 
-        m = re.match("\\s+Total Charge =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Total Charge =\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 

--- a/test/tests_engine/mulliken.py
+++ b/test/tests_engine/mulliken.py
@@ -2,69 +2,71 @@
 import re
 import os
 
+
 def obtain_mulliken(file_in):
-   lista = []
-   for line in file_in.readlines():
-      m = re.match("\s+\d+\s+\d+\s+([0-9.-]+)",line)
-      if m:
-         lista.append(float(m.group(1)))
+    lista = []
+    for line in file_in.readlines():
+        m = re.match("\\s+\\d+\\s+\\d+\\s+([0-9.-]+)", line)
+        if m:
+            lista.append(float(m.group(1)))
 
-      m = re.match("\s+Total Charge =\s+([0-9.-]+)",line)
-      if m:
-         lista.append(float(m.group(1)))
+        m = re.match("\\s+Total Charge =\\s+([0-9.-]+)", line)
+        if m:
+            lista.append(float(m.group(1)))
 
-   return lista
+    return lista
 
-def error(mull,mull_ok):
-   dim1 = len(mull)
-   dim2 = len(mull_ok)
-   scr = 0
-   if dim1 != dim2:
-      print("There are diffenrent mulliken charges in outputs.")
-      return -1
 
-   for num in range(dim1):
-      value = abs(mull[num] - mull_ok[num])
-      if value > 1e-2:
-         src = -1
-         print("Error in mulliken charges:")
-         print("Valor en mulliken",mull[num])
-         print("Valor en mulliken.ok",mull_ok[num])
+def error(mull, mull_ok):
+    dim1 = len(mull)
+    dim2 = len(mull_ok)
+    scr = 0
+    if dim1 != dim2:
+        print("There are diffenrent mulliken charges in outputs.")
+        return -1
 
-   return scr
+    for num in range(dim1):
+        value = abs(mull[num] - mull_ok[num])
+        if value > 1e-2:
+            src = -1
+            print("Error in mulliken charges:")
+            print("Valor en mulliken", mull[num])
+            print("Valor en mulliken.ok", mull_ok[num])
+
+    return scr
 
 
 def Check():
-   # Output
-   mull = []
-   is_file = os.path.isfile("mulliken")
-   if is_file == False:
-      print("The mulliken file is missing.")
-      return -1
+    # Output
+    mull = []
+    is_file = os.path.isfile("mulliken")
+    if not is_file:
+        print("The mulliken file is missing.")
+        return -1
 
-   f = open("mulliken","r")
-   mull = obtain_mulliken(f)
-   f.close()
-   if not mull:
-      print("Error in reading mulliken.")
-      return -1
+    f = open("mulliken", "r")
+    mull = obtain_mulliken(f)
+    f.close()
+    if not mull:
+        print("Error in reading mulliken.")
+        return -1
 
-   # Ideal Output
-   is_file = os.path.isfile("mulliken.ok")
-   if is_file == False:
-      print("The mulliken.ok file is missing.")
-      return -1
+    # Ideal Output
+    is_file = os.path.isfile("mulliken.ok")
+    if not is_file:
+        print("The mulliken.ok file is missing.")
+        return -1
 
-   f = open("mulliken.ok","r")
-   mullok = []
-   mullok = obtain_mulliken(f)
-   f.close()
-   if not mullok:
-      print("Error in reading mulliken.ok.")
-      return -1
+    f = open("mulliken.ok", "r")
+    mullok = []
+    mullok = obtain_mulliken(f)
+    f.close()
+    if not mullok:
+        print("Error in reading mulliken.ok.")
+        return -1
 
-   ok_output = error(mull,mullok)
-   if ok_output != 0:
-      print("Test Mulliken:   ERROR")
-   else:
-      print("Test Mulliken:   OK")
+    ok_output = error(mull, mullok)
+    if ok_output != 0:
+        print("Test Mulliken:   ERROR")
+    else:
+        print("Test Mulliken:   OK")

--- a/test/tests_engine/restart.py
+++ b/test/tests_engine/restart.py
@@ -2,34 +2,35 @@
 import os
 import re
 
-def read_restart(file_in):
-   is_file = os.path.isfile("restart.in")
-   if is_file == False:
-      print("The restart.in file doesn't exist.")
-      return -1
 
-   for line in file_in.readlines():
-      m = re.match("\s+VCInp =\s+(\w)",line)
-      if m:
-        rest = "".join(m.group(1))
-        if rest == "T":
-           return 0
-        else:
-           print("The test didn't read restart.in file.")
-           return -1
+def read_restart(file_in):
+    is_file = os.path.isfile("restart.in")
+    if not is_file:
+        print("The restart.in file doesn't exist.")
+        return -1
+
+    for line in file_in.readlines():
+        m = re.match("\\s+VCInp =\\s+(\\w)", line)
+        if m:
+            rest = "".join(m.group(1))
+            if rest == "T":
+                return 0
+            else:
+                print("The test didn't read restart.in file.")
+                return -1
+
 
 def Check():
-   # Output
-   is_file = os.path.isfile("output")
-   if is_file == False:
-      print("The output file is missing.")
-      return -1
+    # Output
+    is_file = os.path.isfile("output")
+    if not is_file:
+        print("The output file is missing.")
+        return -1
 
-   f = open("output","r")
-   
-   error = read_restart(f)
-   if error != 0:
-      print("Test Restart:    ERROR")
-   else:
-      print("Test Restart:    OK")
+    f = open("output", "r")
 
+    error = read_restart(f)
+    if error != 0:
+        print("Test Restart:    ERROR")
+    else:
+        print("Test Restart:    OK")

--- a/test/tests_engine/restart.py
+++ b/test/tests_engine/restart.py
@@ -10,7 +10,7 @@ def read_restart(file_in):
         return -1
 
     for line in file_in.readlines():
-        m = re.match("\\s+VCInp =\\s+(\\w)", line)
+        m = re.match(r"\s+VCInp =\s+(\w)", line)
         if m:
             rest = "".join(m.group(1))
             if rest == "T":

--- a/tools/densdif.py
+++ b/tools/densdif.py
@@ -1,51 +1,55 @@
 #!/usr/bin/python3
 import numpy as np
 
-def read_dens( file_name ):
 
-    data_file = open( file_name, "r" )
+def read_dens(file_name):
+
+    data_file = open(file_name, "r")
 
     dens_vals = []
     for data_line in data_file.readlines():
-        dens_val1 = float( data_line.split()[0] )
-        dens_vals.append( dens_val1 )
+        dens_val1 = float(data_line.split()[0])
+        dens_vals.append(dens_val1)
 
     data_file.close()
     return dens_vals
 
-def print_dens_td( file_name, dens_vals ):
 
-    data_file = open( file_name, 'w')
+def print_dens_td(file_name, dens_vals):
+
+    data_file = open(file_name, "w")
 
     for dens_val1 in dens_vals:
-        data_file.write( (" %12.9E  %12.9E \n") % (dens_val1,0.0) )
+        data_file.write((" %12.9E  %12.9E \n") % (dens_val1, 0.0))
 
     data_file.close()
     return 0
 
-def print_dens( file_name, dens_vals ):
 
-    data_file = open( file_name, 'w')
+def print_dens(file_name, dens_vals):
+
+    data_file = open(file_name, "w")
 
     basis_size = int(np.sqrt(len(dens_vals)))
     n_count = 0
     for dens_val1 in dens_vals:
-        if ( n_count % basis_size != 0):
+        if n_count % basis_size != 0:
             dens_val1 = dens_val1 * 2.0
-        data_file.write( (" %12.9E ") % (dens_val1) )
+        data_file.write((" %12.9E ") % (dens_val1))
 
-        n_count = n_count +1
-        if (n_count % basis_size == 0):
-            data_file.write ("\n")
+        n_count = n_count + 1
+        if n_count % basis_size == 0:
+            data_file.write("\n")
     data_file.close()
     return 0
+
 
 dens0 = read_dens("dens_neg.in")
 dens1 = read_dens("dens_pos.in")
 
 densf = []
-for idx in range( len( dens1 ) ):
-    densf.append( dens1[idx] - dens0[idx] )
+for idx in range(len(dens1)):
+    densf.append(dens1[idx] - dens0[idx])
 
 print_dens("dens_dif.out", densf)
 print_dens_td("dens_dif_td.out", densf)


### PR DESCRIPTION
Reformat python to match black standard

This PR reformats all the code to match the pep8 python standard and enables the linter to prevent further regressions.

Command ran:

`black .`

https://github.com/psf/black (`apt install black`)

Currently ran 
```
$ black --version
black, version 19.3b0
```

Next PR will contain actual code fixes with some type hints.