### PR TITLE
Use mypy for stronger python checks

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -31,6 +31,7 @@ jobs:
           # TODO: Enable this when codebase is clang-format compliant.
           # VALIDATE_CPP: true
           VALIDATE_PYTHON_BLACK: true
+          VALIDATE_PYTHON_MYPY: true
           # TODO: Enable this when codebase is bash-exec compliant.
           # VALIDATE_BASH: true 
           # VALIDATE_BASH_EXEC: true 

--- a/test/compile.py
+++ b/test/compile.py
@@ -3,16 +3,17 @@
 import os
 import subprocess
 import itertools
+from typing import List, Dict, Tuple, Iterator
 
 
-def set_options(flag):
+def set_options(flag_set: Dict[str, str]) -> str:
     opt = ["%s=%s" % (k, v) for (k, v) in flag_set.items()]
     opt_str = "%s" % (" ".join(opt),)
     options = opt_str.rstrip()
     return options
 
 
-def compile_lio(options):
+def compile_lio(options: str) -> int:
     liodir = os.path.abspath("../")
     devnull = open(os.devnull, "w")
     cmd = ["tests_engine/build.sh", liodir, options]
@@ -21,56 +22,43 @@ def compile_lio(options):
     return process.returncode
 
 
-def run_lio():
+def run_lio() -> int:
     cmd = ["./new_tests.py"]
     process = subprocess.Popen(cmd, cwd=os.path.abspath("."))
     process.wait()
     return process.returncode
 
 
-# Verifies if CUDA is installed.
-
-
-def cuda_is_installed():
+def cuda_is_installed() -> bool:
+    """Verifies if CUDA is installed."""
     devnull = open(os.devnull, "wb")
-    process = subprocess.Popen(
-        ["nvcc --version"], shell=True, stdout=devnull, stderr=devnull
-    )
+    command = ["nvcc --version"]
+
+    process = subprocess.Popen(command, shell=True, stdout=devnull, stderr=devnull)
     try:
-        stdout, stderr = process.communicate()
+        _, _ = process.communicate()
     except BaseException:
         process.kill()
         process.wait()
         raise
     retcode = process.poll()
-
-    is_installed = False
-    if retcode == 0:
-        is_installed = True
-
+    is_installed = retcode == 0
     return is_installed
 
 
-# Checks if Intel compilers are present.
-
-
-def intel_is_installed():
+def intel_is_installed() -> bool:
+    """Checks if Intel compilers are present"""
     devnull = open(os.devnull, "wb")
-    process = subprocess.Popen(
-        ["icc --version"], shell=True, stdout=devnull, stderr=devnull
-    )
+    command = ["icc --version"]
+    process = subprocess.Popen(command, shell=True, stdout=devnull, stderr=devnull)
     try:
-        stdout, stderr = process.communicate()
+        _, _ = process.communicate()
     except BaseException:
         process.kill()
         process.wait()
         raise
     retcode = process.poll()
-
-    is_installed = False
-    if retcode == 0:
-        is_installed = True
-
+    is_installed = retcode == 0
     return is_installed
 
 
@@ -81,11 +69,14 @@ if __name__ == "__main__":
         comp.append("cuda")
     if intel_is_installed():
         comp.append("intel")
-    seq = list(itertools.product(["0", "1"], repeat=len(comp)))
-    all_sets = []
+
+    switches = ["0", "1"]
+    zips: Iterator[Tuple[str, ...]] = itertools.product(switches, repeat=len(comp))
+    seq: List[Tuple[str, ...]] = list(zips)
+    all_sets: List[Dict[str, str]] = []
 
     for cases in seq:
-        compile_opts = dict([(comp[i], cases[i]) for i in range(0, len(comp))])
+        compile_opts = dict(zip(comp, cases))
         if cuda_is_installed():
             if compile_opts["cuda"] == "1":
                 compile_opts["cuda"] = "2"

--- a/test/compile.py
+++ b/test/compile.py
@@ -71,11 +71,13 @@ if __name__ == "__main__":
         comp.append("intel")
 
     switches = ["0", "1"]
-    zips: Iterator[Tuple[str, ...]] = itertools.product(switches, repeat=len(comp))
-    seq: List[Tuple[str, ...]] = list(zips)
+    all_combinations_tuple: Iterator[Tuple[str, ...]] = itertools.product(
+        switches, repeat=len(comp)
+    )
+    all_combinations: List[Tuple[str, ...]] = list(all_combinations_tuple)
     all_sets: List[Dict[str, str]] = []
 
-    for cases in seq:
+    for cases in all_combinations:
         compile_opts = dict(zip(comp, cases))
         if cuda_is_installed():
             if compile_opts["cuda"] == "1":

--- a/test/new_tests.py
+++ b/test/new_tests.py
@@ -4,6 +4,7 @@ import re
 import os
 import argparse
 import subprocess
+from typing import List
 
 
 def lio_env():
@@ -24,7 +25,7 @@ def lio_env():
     return lioenv
 
 
-def run_lio(dirs_with_tests):
+def run_lio(dirs_with_tests: List[str]):
     "Runs all Tests"
     lioenv = lio_env()
 

--- a/test/new_tests.py
+++ b/test/new_tests.py
@@ -4,10 +4,10 @@ import re
 import os
 import argparse
 import subprocess
-from typing import List
+from typing import List, Dict
 
 
-def lio_env():
+def lio_env() -> Dict[str, str]:
     """
     Sets lio enviroment variables, adding g2g and
     lioamber to LD_LIBRARY_PATH.
@@ -25,7 +25,7 @@ def lio_env():
     return lioenv
 
 
-def run_lio(dirs_with_tests: List[str]):
+def run_lio(dirs_with_tests: List[str]) -> None:
     "Runs all Tests"
     lioenv = lio_env()
 
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         "--filter_rx", help="RegExp used to filter which tests are run.", default=".*"
     )
     args = parser.parse_args()
-    filterrx = args.filter_rx
+    filterrx: str = args.filter_rx
 
     # This obtain tests folder
     subdirs = list(os.walk("LIO_test/"))[0][1]
@@ -70,4 +70,4 @@ if __name__ == "__main__":
         dirs_with_tests[i] = "LIO_test/" + dirs_with_tests[i]
 
     # Run lio
-    filed = run_lio(dirs_with_tests)
+    run_lio(dirs_with_tests)

--- a/test/run_travis_test.py
+++ b/test/run_travis_test.py
@@ -4,6 +4,7 @@ import re
 import os
 import argparse
 import subprocess
+from typing import List
 
 
 def lio_env():
@@ -24,7 +25,7 @@ def lio_env():
     return lioenv
 
 
-def run_lio(dirs_with_tests):
+def run_lio(dirs_with_tests: List[str]):
     "Runs all Tests"
     lioenv = lio_env()
 

--- a/test/run_travis_test.py
+++ b/test/run_travis_test.py
@@ -4,10 +4,10 @@ import re
 import os
 import argparse
 import subprocess
-from typing import List
+from typing import List, Dict
 
 
-def lio_env():
+def lio_env() -> Dict[str, str]:
     """
     Sets lio enviroment variables, adding g2g and
     lioamber to LD_LIBRARY_PATH.
@@ -25,7 +25,7 @@ def lio_env():
     return lioenv
 
 
-def run_lio(dirs_with_tests: List[str]):
+def run_lio(dirs_with_tests: List[str]) -> None:
     "Runs all Tests"
     lioenv = lio_env()
 
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         "--filter_rx", help="RegExp used to filter which tests are run.", default=".*"
     )
     args = parser.parse_args()
-    filterrx = args.filter_rx
+    filterrx: str = args.filter_rx
 
     # This obtain tests folder
     subdirs = list(os.walk("LIO_test/"))[0][1]
@@ -64,4 +64,4 @@ if __name__ == "__main__":
         dirs_with_tests[i] = "LIO_test/" + dirs_with_tests[i]
 
     # Run lio
-    filed = run_lio(dirs_with_tests)
+    run_lio(dirs_with_tests)

--- a/test/tests_engine/becke.py
+++ b/test/tests_engine/becke.py
@@ -34,10 +34,12 @@ def error(mull: List[float], mull_ok: List[float]) -> Literal[0, -1]:
             print("Valor en becke", mull[num])
             print("Valor en becke.ok", mull_ok[num])
 
-    return scr
+    if scr == 0:
+        return 0
+    return -1
 
 
-def Check():
+def Check() -> Literal[0, -1]:
     # Output
     mull = []
     is_file = os.path.isfile("becke")
@@ -71,3 +73,4 @@ def Check():
         print("Test Becke:      ERROR")
     else:
         print("Test Becke:      OK")
+    return 0

--- a/test/tests_engine/becke.py
+++ b/test/tests_engine/becke.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
-import re
 import os
+import re
+from typing import List, Literal, TextIO
 
 
-def obtain_becke(file_in):
-    lista = []
+def obtain_becke(file_in: TextIO) -> List[float]:
+    lista: List[float] = []
     for line in file_in.readlines():
-        m = re.match("\\s+\\d+\\s+\\d+\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+\d+\s+\d+\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 
-        m = re.match("\\s+Total Charge =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Total Charge =\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 
     return lista
 
 
-def error(mull, mull_ok):
+def error(mull: List[float], mull_ok: List[float]) -> Literal[0, -1]:
     dim1 = len(mull)
     dim2 = len(mull_ok)
     scr = 0
@@ -28,7 +29,7 @@ def error(mull, mull_ok):
     for num in range(dim1):
         value = abs(mull[num] - mull_ok[num])
         if value > 1e-2:
-            src = -1
+            scr = -1
             print("Error in becke charges:")
             print("Valor en becke", mull[num])
             print("Valor en becke.ok", mull_ok[num])

--- a/test/tests_engine/dipole.py
+++ b/test/tests_engine/dipole.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os
 import re
-from typing import List, Literal, TextIO
+from typing import Iterable, List, Literal, TextIO, Tuple
 
 
 def obtain_dipole(file_in: TextIO) -> List[float]:
@@ -39,10 +39,12 @@ def error(dip: List[float], dip_ok: List[float]) -> Literal[0, -1]:
             print("Value of dipole moment", dip[num])
             print("Value of ideal dipole moment", dip_ok[num])
 
-    return scr
+    if scr == 0:
+        return 0
+    return -1
 
 
-def Check(*opt):
+def Check(*opt: str) -> Literal[0, -1]:
     option = "".join(opt)
 
     # Ouput
@@ -83,3 +85,4 @@ def Check(*opt):
         print("Test Dipole:     ERROR")
     else:
         print("Test Dipole:     OK")
+    return 0

--- a/test/tests_engine/dipole.py
+++ b/test/tests_engine/dipole.py
@@ -53,7 +53,6 @@ def Check(*opt: str) -> Literal[0, -1]:
     else:
         file_in = "dipole_moment"
 
-    dip = []
     is_file = os.path.isfile(file_in)
     if not is_file:
         print("The %s file is missing." % file_in)

--- a/test/tests_engine/dipole.py
+++ b/test/tests_engine/dipole.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-import re
 import os
+import re
+from typing import List, Literal, TextIO
 
 
-def obtain_dipole(file_in):
-    dip = []
-    condition = re.match("\\w+td", file_in.name)
+def obtain_dipole(file_in: TextIO) -> List[float]:
+    dip: List[float] = []
+    condition = re.match(r"\w+td", file_in.name)
 
     if condition:
-        patron = "\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)\\s+([0-9.-]+E[-+0-9]\\d+)"
+        patron = r"\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)\s+([0-9.-]+E[-+0-9]\d+)"
     else:
-        patron = "\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)\\s+([0-9.-E-\\d+]+)"
+        patron = (
+            r"\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)\s+([0-9.-E-\d+]+)"
+        )
 
     for line in file_in.readlines():
         m = re.match(patron, line)
@@ -20,7 +23,7 @@ def obtain_dipole(file_in):
     return dip
 
 
-def error(dip, dip_ok):
+def error(dip: List[float], dip_ok: List[float]) -> Literal[0, -1]:
     dim1 = len(dip)
     dim2 = len(dip_ok)
     scr = 0
@@ -31,7 +34,7 @@ def error(dip, dip_ok):
     for num in range(dim1):
         value = abs(dip[num] - dip_ok[num])
         if value > 1e-3:
-            src = -1
+            scr = -1
             print("Error in dipole:")
             print("Value of dipole moment", dip[num])
             print("Value of ideal dipole moment", dip_ok[num])

--- a/test/tests_engine/energy.py
+++ b/test/tests_engine/energy.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import os
 import re
-from typing import List, Literal, TextIO, Union
+from typing import List, Literal, TextIO, Tuple
 
 
-def obtain_energies(file_in: TextIO) -> Union[List[float], Literal[-1]]:
+def obtain_energies(file_in: TextIO) -> Tuple[Literal[0, -1], List[float]]:
     energies = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     for line in file_in.readlines():
         # Total Energy
@@ -53,9 +53,9 @@ def obtain_energies(file_in: TextIO) -> Union[List[float], Literal[-1]]:
             energies[8] = float(m.group(1))
 
     if len(energies) < 1:
-        return -1
+        return (-1, [])
 
-    return energies
+    return (0, energies)
 
 
 def error(ene: List[float], ene_ok: List[float]) -> Literal[0, -1]:
@@ -88,7 +88,9 @@ def error(ene: List[float], ene_ok: List[float]) -> Literal[0, -1]:
             print("Value in output", ene[num])
             print("Value in output.ok", ene_ok[num])
 
-    return scr
+    if scr == 0:
+        return 0
+    return -1
 
 
 def Check() -> Literal[0, -1]:
@@ -99,10 +101,9 @@ def Check() -> Literal[0, -1]:
         return -1
 
     f = open("output", "r")
-    energies = []
-    energies = obtain_energies(f)
+    status, energies = obtain_energies(f)
     f.close()
-    if not energies:
+    if status != 0:
         print("Error in reading energies in output.")
         return -1
 
@@ -113,10 +114,9 @@ def Check() -> Literal[0, -1]:
         return -1
 
     f = open("output.ok", "r")
-    energiesok = []
-    energiesok = obtain_energies(f)
+    status, energiesok = obtain_energies(f)
     f.close()
-    if not energiesok:
+    if status != 0:
         print("Error in reading energies in output.ok.")
         return -1
 

--- a/test/tests_engine/energy.py
+++ b/test/tests_engine/energy.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import os
 import re
-from typing import List, Literal, TextIO
+from typing import List, Literal, TextIO, Union
 
 
-def obtain_energies(file_in: TextIO) -> List[float]:
+def obtain_energies(file_in: TextIO) -> Union[List[float], Literal[-1]]:
     energies = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     for line in file_in.readlines():
         # Total Energy
@@ -91,7 +91,7 @@ def error(ene: List[float], ene_ok: List[float]) -> Literal[0, -1]:
     return scr
 
 
-def Check():
+def Check() -> Literal[0, -1]:
     # Output
     is_file = os.path.isfile("output")
     if not is_file:
@@ -126,3 +126,4 @@ def Check():
         print("Test Energy:     ERROR")
     else:
         print("Test Energy:     OK")
+    return 0

--- a/test/tests_engine/energy.py
+++ b/test/tests_engine/energy.py
@@ -1,54 +1,54 @@
 #!/usr/bin/env python3
-import re
 import os
-import subprocess
+import re
+from typing import List, Literal, TextIO
 
 
-def obtain_energies(file_in):
+def obtain_energies(file_in: TextIO) -> List[float]:
     energies = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     for line in file_in.readlines():
         # Total Energy
-        m = re.match("\\s+Total energy =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Total energy =\s+([0-9.-]+)", line)
         if m:
             energies[0] = float(m.group(1))
 
         # One Electron Energy
-        m = re.match("\\s+One electron =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+One electron =\s+([0-9.-]+)", line)
         if m:
             energies[1] = float(m.group(1))
 
         # Coulomb Energy
-        m = re.match("\\s+Coulomb\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Coulomb\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[2] = float(m.group(1))
 
         # Nuclear Energy
-        m = re.match("\\s+Nuclear\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Nuclear\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[3] = float(m.group(1))
 
         # Correlation - Exchange Energy
-        m = re.match("\\s+Exch. Corr.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Exch. Corr.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[4] = float(m.group(1))
 
         # Exact exchange for hybrid functionals.
-        m = re.match("\\s+Exact. Exc.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Exact. Exc.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[5] = float(m.group(1))
 
         # QM-MM nuclear repulsion.
-        m = re.match("\\s+QM-MM nuc.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+QM-MM nuc.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[6] = float(m.group(1))
 
         # QM-MM electron attraction.
-        m = re.match("\\s+QM-MM elec.\\s+ =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+QM-MM elec.\s+ =\s+([0-9.-]+)", line)
         if m:
             energies[7] = float(m.group(1))
 
         # DFT-D3 energy.
-        m = re.match("\\s+DFTD3 Energy =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+DFTD3 Energy =\s+([0-9.-]+)", line)
         if m:
             energies[8] = float(m.group(1))
 
@@ -58,7 +58,7 @@ def obtain_energies(file_in):
     return energies
 
 
-def error(ene, ene_ok):
+def error(ene: List[float], ene_ok: List[float]) -> Literal[0, -1]:
     tipo = [
         "Total energy",
         "One electron",

--- a/test/tests_engine/forces.py
+++ b/test/tests_engine/forces.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os
 import re
-from typing import List, TextIO
+from typing import List, Literal, TextIO
 
 
 def obtain_forces(file_in: TextIO) -> List[float]:
@@ -35,7 +35,7 @@ def error(fc: List[float], fc_ok: List[float]) -> int:
     return scr
 
 
-def Check():
+def Check() -> Literal[0, -1]:
     # Output
     fc = []
     is_file = os.path.isfile("forces")
@@ -68,3 +68,4 @@ def Check():
         print("Test Forces:     ERROR")
     else:
         print("Test Forces:     OK")
+    return 0

--- a/test/tests_engine/forces.py
+++ b/test/tests_engine/forces.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-import re
 import os
+import re
+from typing import List, TextIO
 
 
-def obtain_forces(file_in):
-    lista = []
+def obtain_forces(file_in: TextIO) -> List[float]:
+    lista: List[float] = []
     for line in file_in.readlines():
-        m = re.match("\\s+\\d+\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+\d+\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
             lista.append(float(m.group(2)))
@@ -15,7 +16,7 @@ def obtain_forces(file_in):
     return lista
 
 
-def error(fc, fc_ok):
+def error(fc: List[float], fc_ok: List[float]) -> int:
     dim1 = len(fc)
     dim2 = len(fc_ok)
     scr = 0

--- a/test/tests_engine/fukui.py
+++ b/test/tests_engine/fukui.py
@@ -4,7 +4,7 @@ import re
 from typing import List, Literal, TextIO, Union
 
 
-def obtain_fukui(file_in: TextIO) -> Union[List[float], float]:
+def obtain_fukui(file_in: TextIO) -> Union[List[float], Literal[-1]]:
     lista: List[float] = []
     for line in file_in.readlines():
         m = re.match(
@@ -25,12 +25,12 @@ def obtain_fukui(file_in: TextIO) -> Union[List[float], float]:
 def error(fuk: List[float], fukok: List[float]) -> Literal[0, -1, 1]:
     dim1 = len(fuk)
     dim2 = len(fukok)
-    scr = 0
 
     if dim1 != dim2:
         print("There are different number of Fukui charges in outputs.")
         return -1
 
+    scr = 0
     for num in range(dim1):
         value = abs(fuk[num] - fukok[num])
         if value > 1e-2:
@@ -39,10 +39,12 @@ def error(fuk: List[float], fukok: List[float]) -> Literal[0, -1, 1]:
             print("Value of fukui", fuk[num])
             print("Value of fukui.ok", fukok[num])
 
-    return scr
+    if scr == 0:
+        return 0
+    return 1
 
 
-def Check():
+def Check() -> Literal[0, -1]:
     # Output
     fuk = []
     is_file = os.path.isfile("fukui")
@@ -75,3 +77,5 @@ def Check():
         print("Test Fukui:      ERROR")
     else:
         print("Test Fukui:      OK")
+
+    return 0

--- a/test/tests_engine/fukui.py
+++ b/test/tests_engine/fukui.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import os
 import re
-from typing import List, Literal, TextIO, Union
+from typing import List, Literal, TextIO, Tuple
 
 
-def obtain_fukui(file_in: TextIO) -> Union[List[float], Literal[-1]]:
+def obtain_fukui(file_in: TextIO) -> Tuple[Literal[0, -1], List[float]]:
     lista: List[float] = []
     for line in file_in.readlines():
         m = re.match(
@@ -17,12 +17,12 @@ def obtain_fukui(file_in: TextIO) -> Union[List[float], Literal[-1]]:
             lista.append(float(m.group(4)))
 
     if len(lista) < 1:
-        return -1
+        return (-1, [])
 
-    return lista
+    return (0, lista)
 
 
-def error(fuk: List[float], fukok: List[float]) -> Literal[0, -1, 1]:
+def error(fuk: List[float], fukok: List[float]) -> Literal[0, -1]:
     dim1 = len(fuk)
     dim2 = len(fukok)
 
@@ -34,41 +34,39 @@ def error(fuk: List[float], fukok: List[float]) -> Literal[0, -1, 1]:
     for num in range(dim1):
         value = abs(fuk[num] - fukok[num])
         if value > 1e-2:
-            scr = 1
+            scr = -1
             print("Error in fukui:")
             print("Value of fukui", fuk[num])
             print("Value of fukui.ok", fukok[num])
 
     if scr == 0:
         return 0
-    return 1
+    return -1
 
 
 def Check() -> Literal[0, -1]:
     # Output
-    fuk = []
     is_file = os.path.isfile("fukui")
     if not is_file:
         print("The fukui file is missing.")
         return -1
 
     f = open("fukui", "r")
-    fuk = obtain_fukui(f)
+    status, fuk = obtain_fukui(f)
     f.close
-    if not fuk:
+    if status != 0:
         print("Error in reading fukui.")
 
     # Ideal Output
-    fukok = []
     is_file = os.path.isfile("fukui")
     if not is_file:
         print("The fukui.ok file is missing.")
         return -1
 
     f = open("fukui.ok", "r")
-    fukok = obtain_fukui(f)
+    status, fukok = obtain_fukui(f)
     f.close
-    if not fukok:
+    if status != 0:
         print("Error in reading fukui.ok.")
 
     ok_output = error(fuk, fukok)

--- a/test/tests_engine/fukui.py
+++ b/test/tests_engine/fukui.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-import re
 import os
+import re
+from typing import List, Literal, TextIO, Union
 
 
-def obtain_fukui(file_in):
-    lista = []
+def obtain_fukui(file_in: TextIO) -> Union[List[float], float]:
+    lista: List[float] = []
     for line in file_in.readlines():
         m = re.match(
-            "\\s+\\d+\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)\\s+([0-9.-]+)", line
+            r"\s+\d+\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)\s+([0-9.-]+)", line
         )
         if m:
             lista.append(float(m.group(1)))
@@ -21,7 +22,7 @@ def obtain_fukui(file_in):
     return lista
 
 
-def error(fuk, fukok):
+def error(fuk: List[float], fukok: List[float]) -> Literal[0, -1, 1]:
     dim1 = len(fuk)
     dim2 = len(fukok)
     scr = 0

--- a/test/tests_engine/mulliken.py
+++ b/test/tests_engine/mulliken.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
-import re
 import os
+import re
+from typing import List, Literal, TextIO
 
 
-def obtain_mulliken(file_in):
-    lista = []
+def obtain_mulliken(file_in: TextIO) -> List[float]:
+    lista: List[float] = []
     for line in file_in.readlines():
-        m = re.match("\\s+\\d+\\s+\\d+\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+\d+\s+\d+\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 
-        m = re.match("\\s+Total Charge =\\s+([0-9.-]+)", line)
+        m = re.match(r"\s+Total Charge =\s+([0-9.-]+)", line)
         if m:
             lista.append(float(m.group(1)))
 
     return lista
 
 
-def error(mull, mull_ok):
+def error(mull: List[float], mull_ok: List[float]) -> Literal[0, -1]:
     dim1 = len(mull)
     dim2 = len(mull_ok)
     scr = 0
@@ -28,7 +29,7 @@ def error(mull, mull_ok):
     for num in range(dim1):
         value = abs(mull[num] - mull_ok[num])
         if value > 1e-2:
-            src = -1
+            scr = -1
             print("Error in mulliken charges:")
             print("Valor en mulliken", mull[num])
             print("Valor en mulliken.ok", mull_ok[num])

--- a/test/tests_engine/mulliken.py
+++ b/test/tests_engine/mulliken.py
@@ -34,10 +34,12 @@ def error(mull: List[float], mull_ok: List[float]) -> Literal[0, -1]:
             print("Valor en mulliken", mull[num])
             print("Valor en mulliken.ok", mull_ok[num])
 
-    return scr
+    if scr == 0:
+        return 0
+    return -1
 
 
-def Check():
+def Check() -> Literal[0, -1]:
     # Output
     mull = []
     is_file = os.path.isfile("mulliken")
@@ -71,3 +73,4 @@ def Check():
         print("Test Mulliken:   ERROR")
     else:
         print("Test Mulliken:   OK")
+    return 0

--- a/test/tests_engine/restart.py
+++ b/test/tests_engine/restart.py
@@ -22,7 +22,7 @@ def read_restart(file_in: TextIO) -> Literal[0, -1]:
     return -1
 
 
-def Check():
+def Check() -> Literal[0, -1]:
     # Output
     is_file = os.path.isfile("output")
     if not is_file:
@@ -36,3 +36,4 @@ def Check():
         print("Test Restart:    ERROR")
     else:
         print("Test Restart:    OK")
+    return 0

--- a/test/tests_engine/restart.py
+++ b/test/tests_engine/restart.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 import os
 import re
+from typing import Literal, TextIO
 
 
-def read_restart(file_in):
+def read_restart(file_in: TextIO) -> Literal[0, -1]:
     is_file = os.path.isfile("restart.in")
     if not is_file:
         print("The restart.in file doesn't exist.")
         return -1
 
     for line in file_in.readlines():
-        m = re.match("\\s+VCInp =\\s+(\\w)", line)
+        m = re.match(r"\s+VCInp =\s+(\w)", line)
         if m:
             rest = "".join(m.group(1))
             if rest == "T":
@@ -18,6 +19,7 @@ def read_restart(file_in):
             else:
                 print("The test didn't read restart.in file.")
                 return -1
+    return -1
 
 
 def Check():

--- a/tools/densdif.py
+++ b/tools/densdif.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
-import numpy as np
+from math import sqrt
+from typing import List
 
 
-def read_dens(file_name):
-
+def read_dens(file_name: str) -> List[float]:
     data_file = open(file_name, "r")
-
-    dens_vals = []
+    dens_vals: List[float] = []
     for data_line in data_file.readlines():
         dens_val1 = float(data_line.split()[0])
         dens_vals.append(dens_val1)
@@ -15,22 +14,16 @@ def read_dens(file_name):
     return dens_vals
 
 
-def print_dens_td(file_name, dens_vals):
-
+def print_dens_td(file_name: str, dens_vals: List[float]) -> None:
     data_file = open(file_name, "w")
-
     for dens_val1 in dens_vals:
         data_file.write((" %12.9E  %12.9E \n") % (dens_val1, 0.0))
-
     data_file.close()
-    return 0
 
 
-def print_dens(file_name, dens_vals):
-
+def print_dens(file_name: str, dens_vals: List[float]) -> None:
     data_file = open(file_name, "w")
-
-    basis_size = int(np.sqrt(len(dens_vals)))
+    basis_size = int(sqrt(len(dens_vals)))
     n_count = 0
     for dens_val1 in dens_vals:
         if n_count % basis_size != 0:
@@ -41,13 +34,12 @@ def print_dens(file_name, dens_vals):
         if n_count % basis_size == 0:
             data_file.write("\n")
     data_file.close()
-    return 0
 
 
 dens0 = read_dens("dens_neg.in")
 dens1 = read_dens("dens_pos.in")
 
-densf = []
+densf: List[float] = []
 for idx in range(len(dens1)):
     densf.append(dens1[idx] - dens0[idx])
 


### PR DESCRIPTION
This PR adds the linter Mypy[0] which uses standard python type hints (the `: List[str]` annotations) in order to validate the correct types. These types have *no effect* in program execution, but they affect the linters like `mypy` or Visual Studio Code editors that can check for them.

This PR fixes items found by the strictes mypy I could do:
`find . -name *.py -exec mypy --strict --disallow-any-unimported --disallow-any-expr --disallow-any-decorated --disallow-any-explicit --warn-unreachable --warn-incomplete-stub {} \;`

The issues in `check_test.py` for each unit tests are not fixed since they are almost all the same about finding the different modules and not really important.

This actually found a couple of interesting issues by tightening the return values:
1. Some functions were setting the wrong return values! https://github.com/MALBECC/lio/blob/73070f6ffd1fc991c5652ecf943cd249c35a8df2/test/tests_engine/dipole.py#L32 for example was setting a `src` instead of `scr` variable, causing the error code to never surface.
2. Some functions were mixing different return types, assuming the next callers will check them as lists rather than integers. This was fixed by moving to a Tuple of [status, List[]] https://github.com/MALBECC/lio/blob/73070f6ffd1fc991c5652ecf943cd249c35a8df2/test/tests_engine/fukui.py#L15-L18
3. At least one function was actually depending on a global object rather than on the argument https://github.com/MALBECC/lio/blob/73070f6ffd1fc991c5652ecf943cd249c35a8df2/test/compile.py#L7-L8
4. One function was setting a "error = 1" which was inconsistent with "error = -1" in the rest https://github.com/MALBECC/lio/blob/73070f6ffd1fc991c5652ecf943cd249c35a8df2/test/tests_engine/fukui.py#L32

One fun improvement as well here is the use of r-string for regexes (`r"\w+"` vs `"\\w+") which makes the regex a lot more understandable.

In any case, this PR does add a bit of verbosity around some types and some return values (`Literal[0,-1]` versus `int`) and some local variable hints (`my_list: List[float] = []`) but I think it is a good improvement in terms of understanding what these functions produce.

Let me know if this seem useful or the annotations are too much.

[0]: http://mypy-lang.org/